### PR TITLE
Fix PTP port binding not working when running with sudo

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,11 @@ You can Download my Raspberry Pi Image and just Flash the ISO with Rufus: [Relea
 
 Install the Demos and Display from here: https://github.com/hzeller/rpi-rgb-led-matrix
 
-Download my Code (compiled or uncompiled).
+Download my code into the `rpi-rgb-led-matrix` directory:
+
+```
+curl -LO https://raw.githubusercontent.com/Gemini2350/ptp-wallclock/refs/heads/main/ptp-clock.cpp
+```
 
 Compile it:
 
@@ -78,7 +82,13 @@ Running the Application
 PTP uses UDP ports 319 and 320, which are considered privileged ports on
 Linux systems. By default, binding to these ports requires root privileges.
 
-To allow binding to these ports without running the application as root, adjust
+You can run the script with `sudo` (which is recommended for best RGB Matrix performance):
+
+```
+sudo ./ptp-clock
+```
+
+Or to allow binding to these ports without running the application as root, adjust
 the unprivileged port range:
 
 ```
@@ -91,9 +101,10 @@ You can then run the application as a normal user:
 ./ptp-clock
 ```
 
-Note:
-The 6x13B font is not installed by default. To make it available system-wide,
-copy it from the rpi-rgb-led-matrix repository:
+You might get a warning about RGB Matrix performance when running as a normal user.
+
+Note: The 6x13B font is not installed by default. To make it available system-wide,
+copy it from the `rpi-rgb-led-matrix` repository:
 
 ```bash
 sudo mkdir -p /usr/share/fonts/rpi-rgb-led-matrix
@@ -101,6 +112,7 @@ sudo cp fonts/6x13B.bdf /usr/share/fonts/rpi-rgb-led-matrix/
 ```
 
 ## References
+
 [Excuse me, what precise time is It?](https://media.ccc.de/v/39c3-excuse-me-what-precise-time-is-it).
 
 ## Open Issues
@@ -115,7 +127,3 @@ sudo cp fonts/6x13B.bdf /usr/share/fonts/rpi-rgb-led-matrix/
   listens for Sync (and Follow_Up) messages only.
 
 - The network interface is fixed to `eth0`.
-
-
-
-

--- a/ptp-clock.cpp
+++ b/ptp-clock.cpp
@@ -54,6 +54,25 @@ uint32_t get_eth0_ip() {
 }
 
 int main(int argc, char **argv) {
+    // --- Multicast-Sockets ---
+    int sock_sync = socket(AF_INET, SOCK_DGRAM, 0);
+    int sock_followup = socket(AF_INET, SOCK_DGRAM, 0);
+    if (sock_sync < 0 || sock_followup < 0) {
+        perror("socket");
+        return 1;
+    }
+
+    sockaddr_in addr_sync{}, addr_followup{};
+    addr_sync.sin_family = AF_INET;
+    addr_sync.sin_port = htons(319);
+    addr_sync.sin_addr.s_addr = htonl(INADDR_ANY);
+
+    addr_followup.sin_family = AF_INET;
+    addr_followup.sin_port = htons(320);
+    addr_followup.sin_addr.s_addr = htonl(INADDR_ANY);
+
+    bind(sock_sync, (struct sockaddr*)&addr_sync, sizeof(addr_sync));
+    bind(sock_followup, (struct sockaddr*)&addr_followup, sizeof(addr_followup));
 
     // --- Matrix Optionen ---
     RGBMatrix::Options matrix_options;
@@ -84,26 +103,6 @@ int main(int argc, char **argv) {
 
     signal(SIGINT, InterruptHandler);
     signal(SIGTERM, InterruptHandler);
-
-    // --- Multicast-Sockets ---
-    int sock_sync = socket(AF_INET, SOCK_DGRAM, 0);
-    int sock_followup = socket(AF_INET, SOCK_DGRAM, 0);
-    if (sock_sync < 0 || sock_followup < 0) {
-        perror("socket");
-        return 1;
-    }
-
-    sockaddr_in addr_sync{}, addr_followup{};
-    addr_sync.sin_family = AF_INET;
-    addr_sync.sin_port = htons(319);
-    addr_sync.sin_addr.s_addr = htonl(INADDR_ANY);
-
-    addr_followup.sin_family = AF_INET;
-    addr_followup.sin_port = htons(320);
-    addr_followup.sin_addr.s_addr = htonl(INADDR_ANY);
-
-    bind(sock_sync, (struct sockaddr*)&addr_sync, sizeof(addr_sync));
-    bind(sock_followup, (struct sockaddr*)&addr_followup, sizeof(addr_followup));
 
     ip_mreq mreq{};
     mreq.imr_multiaddr.s_addr = inet_addr("224.0.1.129");


### PR DESCRIPTION
Fixes #7.

Adds more information to how to run the application in different scenarios (like with or without `sudo`), and ensures port binding works when run as root, by moving the binding before the RGB LED Matrix library instantiation (which drops privileges after it sets up the matrix).